### PR TITLE
Update .prettierrc configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,15 @@
 {
-  "trailingComma": "es5",
   "singleQuote": true,
-  "jsxSingleQuote": true
+  "tabWidth": 2,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 89,
+  "arrowParens": "avoid",
+  "singleAttributePerLine": true,
+  "jsxSingleQuote": true,
+  "htmlWhitespaceSensitivity": "css",
+  "quoteProps": "as-needed",
+  "endOfLine": "lf",
+  "bracketSpacing": true,
+  "bracketSameLine": true
 }


### PR DESCRIPTION
Update the .prettierrc configuration file to include the following changes:
- Set tab width to 2
- Enable semicolons
- Use trailing commas for all elements
- Set print width to 89
- Use arrow parens "avoid"
- Use single attribute per line
- Use single quotes for JSX
- Set HTML whitespace sensitivity to "css"
- Quote object properties only when necessary
- Set end of line to "lf"
- Enable bracket spacing
- Place brackets on the same line

This commit updates the .prettierrc configuration to align with the desired code formatting style.

```