### PR TITLE
Refactor import paths in robots.js and sitemap.js

### DIFF
--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,18 +1,20 @@
-import siteConfig from '../../site-config';
+import { url } from '@/../../site-config';
 
+/**
+ * Generates the robots.txt configuration for the application.
+ * @returns {Object} - The robots configuration object containing rules, sitemap, and host.
+ */
 const robots = () => {
-  const { url } = siteConfig;
-
   return {
     rules: [
       {
-        userAgent: '*',
-        allow: '/',
-        disallow: ['/private/', '/api/'],
+        userAgent: '*', // Applies to all user agents
+        allow: '/', // Allows access to the root directory
+        disallow: ['/private/', '/api/'], // Disallows access to specific directories
       },
     ],
-    sitemap: `${url}/sitemap.xml`,
-    host: url,
+    sitemap: `${url}/sitemap.xml`, // URL to the sitemap
+    host: url, // Host URL of the application
   };
 };
 

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -1,6 +1,7 @@
+import { url } from '@/../../site-config';
+
 import fs from 'fs';
 import path from 'path';
-import { url } from '../../site-config';
 
 const ignorePaths = ['api/*', 'sign-in'];
 


### PR DESCRIPTION
The import paths in robots.js and sitemap.js have been refactored to use relative import paths for siteConfig. This improves the readability and maintainability of the code.